### PR TITLE
fixed bug: users with admin role can't login

### DIFF
--- a/frontend/app/web/src/modules/auth/RoutePrivate.js
+++ b/frontend/app/web/src/modules/auth/RoutePrivate.js
@@ -13,7 +13,7 @@ const RoutePrivate = ({ role, component, ...props }) => {
   return (
     isAuthenticated
       ? role
-        ? details.role === props.role
+        ? details.role === role
           ? <Route {...props} component={component}/>
           : <Redirect to={userRoutes.userLogin.path}/>
         : <Route {...props} component={component}/>


### PR DESCRIPTION
`Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.`

We get the `role` by destructuring props. so we shouldn't use `props.role` instead we should use `role` variable